### PR TITLE
Adding serial hdf5 gds vfd implementation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "gds/readers/hdf5-gds-vfd"]
+	path = gds/readers/hdf5-gds-vfd
+	url = https://github.com/hpc-io/hdf5
+	branch = cu_dev

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,5 @@
+
+
 [submodule "gds/readers/hdf5-gds-vfd"]
 	path = gds/readers/hdf5-gds-vfd
-	url = https://github.com/hpc-io/hdf5
-	branch = cu_dev
+	url = https://github.com/hpc-io/vfd-gds.git


### PR DESCRIPTION
This version of HDF5 can be compiled with GDS VFD which enables GPUDirect Storage. You can pass CUDA GPU buffers directly to the HDF5 API, and the GDS VFD interfaces with cuFile API. 