### PR TITLE
Use NVIDIA Container Runtime to inject GDS and MOFED devices

### DIFF
--- a/gds/docker/gds-run-container
+++ b/gds/docker/gds-run-container
@@ -21,21 +21,21 @@ else
               ;;
             --enable-gds)
               GDS="1"
-              shift 
+              shift
               ;;
             --enable-gds-compat)
               GDS_COMPAT="1"
-              shift 
+              shift
               ;;
             -h | --help | help)
               CMD="help"
               DOCKER_OPTIONS+=" $1"
-              shift 
+              shift
               ;;
 
             *) # unknown option
               DOCKER_OPTIONS+=" $1"
-              shift 
+              shift
               ;;
           esac
         done
@@ -44,26 +44,14 @@ fi
 if [ "x$MOFED" = "x1" ]; then
 	uverbs=$(ls /dev/infiniband/uverbs* 2>&1)
 	if [ $? -eq 0 ] ; then
-		UVERB_DEPS=" --net host --cap-add=IPC_LOCK --device=/dev/infiniband/rdma_cm " 
-		for dev in $uverbs
-		do
-			UVERB_DEVS="${UVERB_DEVS} --device=$dev"
-		done
-		MOFED_OPTS="${UVERB_DEPS} ${UVERB_DEVS}"
+		MOFED_OPTS=" --net host --cap-add=IPC_LOCK -e NVIDIA_MOFED=enabled "
 	fi
 fi
 
 if [ "x$GDS" = "x1" ] ; then
 	nvfs_devs=$(ls /dev/nvidia-fs* 2>&1)
 	if [ $? -eq 0 ] ; then
-		NVFS_DEPS=" --ipc host  --volume /run/udev:/run/udev:ro "
-		for dev in ${nvfs_devs}
-		do
-			NVFS_DEVS="${NVFS_DEVS} --device=$dev"
-		done
-	else
-		echo "skipping nvidia_fs kernel module load"
-		exit
+		GDS_OPTS=" --ipc host  -e NVIDIA_GDS=enabled "
 	fi
 	GDS_OPTS="${NVFS_DEPS} ${NVFS_DEVS}"
 elif [ "x$GDS_COMPAT" = "x1" ] ; then
@@ -73,15 +61,15 @@ fi
 
 
 if [ "$CMD" = "run" ] ;then
-	echo exec docker " run ${GDS_OPTS} ${MOFED_OPTS} ${DOCKER_OPTIONS}"
-	exec docker run ${GDS_OPTS} ${MOFED_OPTS} ${DOCKER_OPTIONS}
+	echo exec docker " run --runtime=nvidia ${GDS_OPTS} ${MOFED_OPTS} ${DOCKER_OPTIONS}"
+	exec docker run --runtime=nvidia ${GDS_OPTS} ${MOFED_OPTS} ${DOCKER_OPTIONS}
 elif [ "$CMD" = "help" ] ; then
-     
+
       echo "Note: "`basename $0`" is a wrapper script around docker to provide GDS specific flags and device(s)"
       echo
       echo "GPUDirect Storage Options:"
       echo " 	--enable-gds         pass nvidia_fs character device(s) and flags"
-      echo " 	--enable-gds-compat  allow for GDS to work in compat mode only" 
+      echo " 	--enable-gds-compat  allow for GDS to work in compat mode only"
       echo " 	--enable-mofed pass  mellanox character device(s) and flags"
       echo
       docker ${DOCKER_OPTIONS}


### PR DESCRIPTION
With the release of NVIDIA Container Toolkit v1.11.0-rc.1 the NVIDIA Container Runtime supports injecting GDS and MOFED devices based on the presence (and values) of the `NVIDIA_GDS=enabled` and `NVIDIA_MOFED=enabled` environment variables.

This change uses these environment variables instead of constructing the docker arguments manually.

Signed-off-by: Evan Lezar <elezar@nvidia.com>