### PR TITLE
Update Makefile to remove deprecated architectures

### DIFF
--- a/gds/samples/Makefile
+++ b/gds/samples/Makefile
@@ -81,17 +81,10 @@ objs = $(samples:.cc=)  $(samples:.cc=_static)
 cuobjs = $(cusamples:.cu=) vectorAdd.o
 build: $(objs) $(cuobjs)
 
-CUDA_ARCH = -gencode=arch=compute_60,code=sm_60 \
-            -gencode=arch=compute_61,code=sm_61 \
-            -gencode=arch=compute_61,code=sm_61 \
-            -gencode=arch=compute_61,code=sm_61 \
-            -gencode=arch=compute_62,code=sm_62 \
-            -gencode=arch=compute_70,code=sm_70 \
-            -gencode=arch=compute_72,code=sm_72 \
-            -gencode=arch=compute_75,code=sm_75 \
+CUDA_ARCH = -gencode=arch=compute_75,code=sm_75 \
             -gencode=arch=compute_80,code=sm_80 \
             -gencode=arch=compute_86,code=sm_86 \
-            -gencode=arch=compute_80,code=compute_80
+            -gencode=arch=compute_86,code=compute_86
 
 vectorAdd.o : vectorAdd.cu
 	$(NVCC) $(INCLUDES) --cudadevrt static --cudart static \


### PR DESCRIPTION
This MR removes compilation for deprecated architectures (Maxwell, Pascal and Volta).