### PR TITLE
CUDA 13.2 Update

### DIFF
--- a/gds/samples/1_cuFile_Basics/error_and_properties.cc
+++ b/gds/samples/1_cuFile_Basics/error_and_properties.cc
@@ -21,8 +21,8 @@
  * PASS: cuFile error status: GPUDirect Storage not supported on current platform
  * ...
  * cuFileDriver Get/SetProperties Usage
- * cuFile driver properties before using setters:
- *   Poll mode bitmask: 00000010
+ * cuFile driver properties after using setters:
+ *   Poll mode bitmask: 00000011
  * ...
  */
 
@@ -45,11 +45,12 @@ static constexpr size_t POLL_THRESH_KB = 32768;
 // Limit application to use a portion of GPU memory for IO usage
 static constexpr size_t LIMIT_BAR_USAGE_KB = 512;
 
-// For internal use, max mmaped buffer size
-static constexpr size_t LIMIT_DIO_SIZE_KB = 64;
-
-// For internal use, allocation of internal buffers
-static constexpr size_t LIMIT_CACHE_SIZE_KB = 64;
+// GPU Bounce Buffer Slab Configuration
+// Defines multiple buffer sizes for flexible memory allocation
+static constexpr size_t SLAB_SIZES_KB[] = {4, 16, 64};
+static constexpr size_t SLAB_COUNTS[] = {4, 2, 1};
+static constexpr int NUM_SLABS = 3;
+// Total cache: 4*4 + 16*2 + 64*1 = 112 KB
 
 int main(void) {
 	CUfileError_t status = {CU_FILE_SUCCESS, CUDA_SUCCESS};
@@ -98,26 +99,6 @@ int main(void) {
 	// Reset the status for cuFileDriver Get/SetProperties
 	std::cout << std::endl << "cuFileDriver Get/SetProperties Usage" << std::endl;
 
-	status = cuFileDriverOpen();
-	if (status.err != CU_FILE_SUCCESS) {
-		std::cerr << "cufile driver open error "
-			<< cuFileGetErrorString(status) << std::endl;
-		return EXIT_FAILURE;
-	}
-
-	status = cuFileDriverGetProperties(&props);
-	if (status.err != CU_FILE_SUCCESS) {
-		std::cerr << "cufile driver get properties failed "
-			<< cuFileGetErrorString(status) << std::endl;
-		return EXIT_FAILURE;
-	}
-	std::cout << "cuFile driver properties before using setters: " << std::endl;
-	std::cout << "  Poll mode bitmask: " << std::bitset<8>(props.nvfs.dcontrolflags) << std::endl;
-	std::cout << "  Poll threshold size: " << props.nvfs.poll_thresh_size << " bytes" << std::endl;
-	std::cout << "  Max pinned mem size: " << props.max_device_pinned_mem_size << " bytes" << std::endl;
-	std::cout << "  Max direct io size: " << props.nvfs.max_direct_io_size << " bytes" << std::endl;
-	std::cout << "  Max cache size: " << props.max_device_cache_size << " bytes" << std::endl;
-
 	status = cuFileDriverSetPollMode(true, POLL_THRESH_KB);
 	if (status.err != CU_FILE_SUCCESS) {
 		std::cerr << "cuFile driver set properties failed "
@@ -132,32 +113,59 @@ int main(void) {
 		return EXIT_FAILURE;
 	}
 
-	status = cuFileDriverSetMaxDirectIOSize(LIMIT_DIO_SIZE_KB);
+	status = cuFileSetParameterGpuBounceBufferSlabArray(SLAB_SIZES_KB, SLAB_COUNTS, NUM_SLABS);
 	if (status.err != CU_FILE_SUCCESS) {
-		std::cerr << "cuFile driver set properties failed "
+		std::cerr << "cuFile driver set slab configuration failed "
 			<< cuFileGetErrorString(status) << std::endl;
 		return EXIT_FAILURE;
 	}
 
-	status = cuFileDriverSetMaxCacheSize(LIMIT_CACHE_SIZE_KB);
+	status = cuFileDriverOpen();
 	if (status.err != CU_FILE_SUCCESS) {
-		std::cerr << "cuFile driver set properties failed "
+		std::cerr << "cufile driver open error "
 			<< cuFileGetErrorString(status) << std::endl;
 		return EXIT_FAILURE;
 	}
 
 	status = cuFileDriverGetProperties(&props);
 	if (status.err != CU_FILE_SUCCESS) {
-		std::cerr << "cuFile driver get properties failed "
+		std::cerr << "cufile driver get properties failed "
 			<< cuFileGetErrorString(status) << std::endl;
 		return EXIT_FAILURE;
 	}
 	std::cout << "cuFile driver properties after using setters: " << std::endl;
+	
+	// Verify poll mode is enabled
+	bool poll_mode_enabled = props.nvfs.dcontrolflags & (1 << CU_FILE_USE_POLL_MODE);
 	std::cout << "  Poll mode bitmask: " << std::bitset<8>(props.nvfs.dcontrolflags) << std::endl;
-	std::cout << "  Poll threshold size: " << props.nvfs.poll_thresh_size << " bytes" << std::endl;
-	std::cout << "  Max pinned mem size: " << props.max_device_pinned_mem_size << " bytes" << std::endl;
-	std::cout << "  Max direct io size: " << props.nvfs.max_direct_io_size << " bytes" << std::endl;
-	std::cout << "  Max cache size: " << props.max_device_cache_size << " bytes" << std::endl;
+	assert(poll_mode_enabled && "Poll mode should be enabled");
+	std::cout << "PASS: Poll mode enabled" << std::endl;
+	
+	// Verify poll threshold size matches what was set
+	std::cout << "  Poll threshold size: " << props.nvfs.poll_thresh_size << " KB" << std::endl;
+	assert(props.nvfs.poll_thresh_size == POLL_THRESH_KB && "Poll threshold should match set value");
+	std::cout << "PASS: Poll threshold size matches" << std::endl;
+	
+	// Verify max pinned mem size matches what was set
+	std::cout << "  Max pinned mem size: " << props.max_device_pinned_mem_size << " KB" << std::endl;
+	assert(props.max_device_pinned_mem_size == LIMIT_BAR_USAGE_KB && "Max pinned mem size should match set value");
+	std::cout << "PASS: Max pinned mem size matches" << std::endl;
+	
+	// Max direct io size and cache size depend on slab configuration
+	std::cout << "  Max direct io size: " << props.nvfs.max_direct_io_size << " KB" << std::endl;
+	// In slab mode, max_direct_io_size should be the largest slab size
+	size_t expected_max_direct_io = SLAB_SIZES_KB[NUM_SLABS - 1]; // Largest slab
+	assert(props.nvfs.max_direct_io_size == expected_max_direct_io && "Max direct IO size should match largest slab");
+	std::cout << "PASS: Max direct IO size matches largest slab" << std::endl;
+	
+	// Max cache size should be the sum of all slabs
+	std::cout << "  Max cache size: " << props.max_device_cache_size << " KB (sum of all slabs)" << std::endl;
+	size_t expected_cache_size = 0;
+	for (int i = 0; i < NUM_SLABS; i++) {
+		expected_cache_size += SLAB_SIZES_KB[i] * SLAB_COUNTS[i];
+	}
+	assert(props.max_device_cache_size == expected_cache_size && "Max cache size should match sum of all slabs");
+	std::cout << "PASS: Max cache size matches sum of slabs (" << expected_cache_size << " KB)" << std::endl;
 
 	status = cuFileDriverClose();
 	if (status.err != CU_FILE_SUCCESS) {

--- a/gds/samples/2_cuFile_Multithreaded/file_control_locks.cc
+++ b/gds/samples/2_cuFile_Multithreaded/file_control_locks.cc
@@ -228,7 +228,7 @@ int main(int argc, char *argv[]) {
 
 	// Parse the GPU ID and open the file
 	gpuid = parseInt(argv[2]);
-	fd = open(argv[1], O_CREAT | O_RDWR | O_DIRECT);
+	fd = open(argv[1], O_CREAT | O_RDWR | O_DIRECT, 0664);
 	if (fd < 0) {
 		std::cerr << "Error: Unable to open file " << argv[1] << " with error "
 			<< cuFileGetErrorString(errno) << std::endl;

--- a/gds/samples/2_cuFile_Multithreaded/highly_concurrent_halfreg.cc
+++ b/gds/samples/2_cuFile_Multithreaded/highly_concurrent_halfreg.cc
@@ -54,13 +54,24 @@
 static constexpr size_t NUM_THREADS = 64;
 static constexpr size_t NUM_GPU_BUFFERS = 4;
 static constexpr size_t CHUNK_SIZE = MiB(1);
-static constexpr size_t MAX_PINNED_MEM_SIZE = KiB(128);
-static constexpr size_t MAX_CACHE_SIZE = KiB(64);
+// API expects KB - convert bytes to KB
+// Calculate the maximum pinned memory size based on the number of registered buffers and the bounce buffer
+// There are NUM_THREADS/2 threads that will have NUM_GPU_BUFFERS registered buffers
+static constexpr size_t NUM_REGISTERED_BUFFERS = NUM_GPU_BUFFERS * NUM_THREADS/2;
+// The unregistered threads will share a single CHUNK_SIZE bounce buffer
+static constexpr size_t MAX_PINNED_MEM_SIZE = TOKiB((NUM_REGISTERED_BUFFERS + 1) * CHUNK_SIZE);  // 129 MiB = 132096 KB
+
+// GPU Bounce Buffer Slab Configuration
+// One 1 MB (1024 KB) slab to handle CHUNK_SIZE allocations
+static constexpr size_t SLAB_SIZES_KB[] = {1024};
+static constexpr size_t SLAB_COUNTS[] = {1};
+static constexpr int NUM_SLABS = 1;
+// Total cache: 1024 KB (1 MB)
 
 /*
  * Each thread allocates GPU memory and invokes cuFileBufRegister
  * on the entire buffer. This is done once; after registering or not 
- * registering the buffers, the thread reads data in chunks into their own set of 64
+ * registering the buffers, the thread reads data in chunks into their own set of 4
  * buffers. The GPU buffer acts as a streaming buffer, allowing data to be
  * directly DMA'ed into the registered memory. This approach is optimal for performance.
  */
@@ -185,17 +196,17 @@ int main(int argc, char *argv[]) {
 		});
 	};
 
-	// Set the maximum pinned memory size to 128 KiB
+	// Set the maximum pinned memory size to 128 MiB
 	status = cuFileDriverSetMaxPinnedMemSize(MAX_PINNED_MEM_SIZE);
 	if (status.err != CU_FILE_SUCCESS) {
 		std::cerr << "cuFileDriverSetMaxPinnedMemSize failed" << std::endl;
 		return EXIT_FAILURE;
 	}
 
-	// Set the maximum cache size to 64 KiB
-	status = cuFileDriverSetMaxCacheSize(MAX_CACHE_SIZE);
+	// Set GPU bounce buffer slab configuration
+	status = cuFileSetParameterGpuBounceBufferSlabArray(SLAB_SIZES_KB, SLAB_COUNTS, NUM_SLABS);
 	if (status.err != CU_FILE_SUCCESS) {
-		std::cerr << "cuFileDriverSetMaxCacheSize failed" << std::endl;
+		std::cerr << "cuFileSetParameterGpuBounceBufferSlabArray failed" << std::endl;
 		return EXIT_FAILURE;
 	}
 
@@ -204,8 +215,8 @@ int main(int argc, char *argv[]) {
 		std::cerr << "Error: cuFileDriverGetProperties failed" << std::endl;
 		return EXIT_FAILURE;
 	}
-	std::cout << "Setting max pinned memory size to: " << props.max_device_pinned_mem_size << " bytes" << std::endl;
-	std::cout << "Setting max cache size to: " << props.max_device_cache_size << " bytes" << std::endl;
+	std::cout << "Setting max pinned memory size to: " << props.max_device_pinned_mem_size << " kilobytes" << std::endl;
+	std::cout << "Setting max cache size to: " << props.max_device_cache_size << " kilobytes (from slab configuration)" << std::endl;
 
 	// Open an individual file descriptor for each thread and allow for half the threads
 	// to use registered buffers and the other half to use unregistered buffers

--- a/gds/samples/Makefile
+++ b/gds/samples/Makefile
@@ -44,8 +44,8 @@ else
 	CUFILE_INCLUDE_PATH ?= /usr/local/cuda/targets/x86_64-linux/include/
 endif
 CXXFLAGS    := -Wall
-CXXFLAGS    += -I $(CUDA_PATH)/include/ 
 CXXFLAGS    += -I $(CUFILE_INCLUDE_PATH)
+CXXFLAGS    += -I $(CUDA_PATH)/include/ 
 CXXFLAGS    += -I ./include/
 ###########################
 # Enable the following line for code coverage

--- a/gds/samples/include/cufile_sample_thrust.hpp
+++ b/gds/samples/include/cufile_sample_thrust.hpp
@@ -23,6 +23,9 @@
 #include <thrust/device_vector.h>
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
+
+// includes, libcudacxx
+#include <cuda/std/iterator>
 #include "cufile_sample_utils.hpp"
 #include "cufile_sample_memmap.hpp"
 
@@ -39,9 +42,9 @@ __device__ long long int d_index = -1;
 template<typename T>
 __global__ void thrust_concurrent_find_kernel(T* begin, T value, size_t numElements, int d) {
 	thrust::device_ptr<T> iter;
-	iter = thrust::find(thrust::device, thrust::device_pointer_cast(begin), thrust::device_pointer_cast(begin+numElements-1), value);
+	iter = thrust::find(thrust::device, thrust::device_pointer_cast(begin), thrust::device_pointer_cast(begin + numElements - 1), value);
 	if (*iter == value) {
-		d_index = thrust::distance(thrust::device_pointer_cast(begin), iter);
+		d_index = thrust::raw_pointer_cast(iter) - begin;
 		d_index += d*numElements;
 	}
 }
@@ -56,15 +59,15 @@ __global__ void thrust_concurrent_find_kernel(T* begin, T value, size_t numEleme
 ////////////////////////////////////////////////////////////////////////////
 template <typename T>
 int thrust_concurrent_find(thrust::device_ptr<T> begin, thrust::device_ptr<T> end, T value, int num_devices) {
-	size_t num_elements = (thrust::distance(begin, end))/num_devices;
+	size_t num_elements = (thrust::raw_pointer_cast(end) - thrust::raw_pointer_cast(begin)) / num_devices;
 
 	cudaStream_t streams[num_devices];
-	for(int i=0; i<num_devices; i++) {
+	for (int i = 0; i < num_devices; i++) {
 		check_cudaruntimecall(cudaSetDevice(i));
 		check_cudaruntimecall(cudaStreamCreateWithFlags(&streams[i], cudaStreamNonBlocking));
 	}
 
-	for (int i=0; i<num_devices; i++) {
+	for (int i = 0; i < num_devices; i++) {
 		check_cudaruntimecall(cudaSetDevice(i));
 		thrust_concurrent_find_kernel<T><<< 1, 1, 0, streams[i]>>>((T*) thrust::raw_pointer_cast(begin+i*num_elements), value, num_elements, i);
 	}


### PR DESCRIPTION
- Updated to utilizing pointer arithmetic vs. calling thrust::distance which is deprecated
- Sync parameter setting APIs with new slab changes in 13.2
- Minor linking change in Makefile