### PR TITLE
Restoring Backwards Compatibility for Samples

### DIFF
--- a/gds/samples/1_cuFile_Basics/error_and_properties.cc
+++ b/gds/samples/1_cuFile_Basics/error_and_properties.cc
@@ -23,7 +23,10 @@
  * cuFileDriver Get/SetProperties Usage
  * cuFile driver properties after using setters:
  *   Poll mode bitmask: 00000011
+ * PASS: Poll mode enabled
  * ...
+ * Note: older GDS versions may print WARN instead of PASS if pre-open
+ * setters are not yet supported.
  */
 
 #include <cstdlib>
@@ -45,12 +48,11 @@ static constexpr size_t POLL_THRESH_KB = 32768;
 // Limit application to use a portion of GPU memory for IO usage
 static constexpr size_t LIMIT_BAR_USAGE_KB = 512;
 
-// GPU Bounce Buffer Slab Configuration
-// Defines multiple buffer sizes for flexible memory allocation
-static constexpr size_t SLAB_SIZES_KB[] = {4, 16, 64};
-static constexpr size_t SLAB_COUNTS[] = {4, 2, 1};
-static constexpr int NUM_SLABS = 3;
-// Total cache: 4*4 + 16*2 + 64*1 = 112 KB
+// For internal use, max mmaped buffer size
+static constexpr size_t LIMIT_DIO_SIZE_KB = 64;
+
+// For internal use, allocation of internal buffers
+static constexpr size_t LIMIT_CACHE_SIZE_KB = 64;
 
 int main(void) {
 	CUfileError_t status = {CU_FILE_SUCCESS, CUDA_SUCCESS};
@@ -113,9 +115,16 @@ int main(void) {
 		return EXIT_FAILURE;
 	}
 
-	status = cuFileSetParameterGpuBounceBufferSlabArray(SLAB_SIZES_KB, SLAB_COUNTS, NUM_SLABS);
+	status = cuFileDriverSetMaxDirectIOSize(LIMIT_DIO_SIZE_KB);
 	if (status.err != CU_FILE_SUCCESS) {
-		std::cerr << "cuFile driver set slab configuration failed "
+		std::cerr << "cuFile driver set properties failed "
+			<< cuFileGetErrorString(status) << std::endl;
+		return EXIT_FAILURE;
+	}
+
+	status = cuFileDriverSetMaxCacheSize(LIMIT_CACHE_SIZE_KB);
+	if (status.err != CU_FILE_SUCCESS) {
+		std::cerr << "cuFile driver set properties failed "
 			<< cuFileGetErrorString(status) << std::endl;
 		return EXIT_FAILURE;
 	}
@@ -134,38 +143,35 @@ int main(void) {
 		return EXIT_FAILURE;
 	}
 	std::cout << "cuFile driver properties after using setters: " << std::endl;
-	
-	// Verify poll mode is enabled
+
 	bool poll_mode_enabled = props.nvfs.dcontrolflags & (1 << CU_FILE_USE_POLL_MODE);
 	std::cout << "  Poll mode bitmask: " << std::bitset<8>(props.nvfs.dcontrolflags) << std::endl;
-	assert(poll_mode_enabled && "Poll mode should be enabled");
-	std::cout << "PASS: Poll mode enabled" << std::endl;
-	
-	// Verify poll threshold size matches what was set
+	std::cout << (poll_mode_enabled ? "PASS" : "WARN") << ": Poll mode "
+		<< (poll_mode_enabled ? "enabled" : "not enabled (setter may require newer GDS)") << std::endl;
+
 	std::cout << "  Poll threshold size: " << props.nvfs.poll_thresh_size << " KB" << std::endl;
-	assert(props.nvfs.poll_thresh_size == POLL_THRESH_KB && "Poll threshold should match set value");
-	std::cout << "PASS: Poll threshold size matches" << std::endl;
-	
-	// Verify max pinned mem size matches what was set
+	std::cout << (props.nvfs.poll_thresh_size == POLL_THRESH_KB ? "PASS" : "WARN")
+		<< ": Poll threshold size "
+		<< (props.nvfs.poll_thresh_size == POLL_THRESH_KB ? "matches" : "did not apply (setter may require newer GDS)")
+		<< std::endl;
+
 	std::cout << "  Max pinned mem size: " << props.max_device_pinned_mem_size << " KB" << std::endl;
-	assert(props.max_device_pinned_mem_size == LIMIT_BAR_USAGE_KB && "Max pinned mem size should match set value");
-	std::cout << "PASS: Max pinned mem size matches" << std::endl;
-	
-	// Max direct io size and cache size depend on slab configuration
+	std::cout << (props.max_device_pinned_mem_size == LIMIT_BAR_USAGE_KB ? "PASS" : "WARN")
+		<< ": Max pinned mem size "
+		<< (props.max_device_pinned_mem_size == LIMIT_BAR_USAGE_KB ? "matches" : "did not apply (setter may require newer GDS)")
+		<< std::endl;
+
 	std::cout << "  Max direct io size: " << props.nvfs.max_direct_io_size << " KB" << std::endl;
-	// In slab mode, max_direct_io_size should be the largest slab size
-	size_t expected_max_direct_io = SLAB_SIZES_KB[NUM_SLABS - 1]; // Largest slab
-	assert(props.nvfs.max_direct_io_size == expected_max_direct_io && "Max direct IO size should match largest slab");
-	std::cout << "PASS: Max direct IO size matches largest slab" << std::endl;
-	
-	// Max cache size should be the sum of all slabs
-	std::cout << "  Max cache size: " << props.max_device_cache_size << " KB (sum of all slabs)" << std::endl;
-	size_t expected_cache_size = 0;
-	for (int i = 0; i < NUM_SLABS; i++) {
-		expected_cache_size += SLAB_SIZES_KB[i] * SLAB_COUNTS[i];
-	}
-	assert(props.max_device_cache_size == expected_cache_size && "Max cache size should match sum of all slabs");
-	std::cout << "PASS: Max cache size matches sum of slabs (" << expected_cache_size << " KB)" << std::endl;
+	std::cout << (props.nvfs.max_direct_io_size == LIMIT_DIO_SIZE_KB ? "PASS" : "WARN")
+		<< ": Max direct IO size "
+		<< (props.nvfs.max_direct_io_size == LIMIT_DIO_SIZE_KB ? "matches" : "did not apply (setter may require newer GDS)")
+		<< std::endl;
+
+	std::cout << "  Max cache size: " << props.max_device_cache_size << " KB" << std::endl;
+	std::cout << (props.max_device_cache_size == LIMIT_CACHE_SIZE_KB ? "PASS" : "WARN")
+		<< ": Max cache size "
+		<< (props.max_device_cache_size == LIMIT_CACHE_SIZE_KB ? "matches" : "did not apply (setter may require newer GDS)")
+		<< std::endl;
 
 	status = cuFileDriverClose();
 	if (status.err != CU_FILE_SUCCESS) {

--- a/gds/samples/2_cuFile_Multithreaded/highly_concurrent_halfreg.cc
+++ b/gds/samples/2_cuFile_Multithreaded/highly_concurrent_halfreg.cc
@@ -54,19 +54,8 @@
 static constexpr size_t NUM_THREADS = 64;
 static constexpr size_t NUM_GPU_BUFFERS = 4;
 static constexpr size_t CHUNK_SIZE = MiB(1);
-// API expects KB - convert bytes to KB
-// Calculate the maximum pinned memory size based on the number of registered buffers and the bounce buffer
-// There are NUM_THREADS/2 threads that will have NUM_GPU_BUFFERS registered buffers
-static constexpr size_t NUM_REGISTERED_BUFFERS = NUM_GPU_BUFFERS * NUM_THREADS/2;
-// The unregistered threads will share a single CHUNK_SIZE bounce buffer
-static constexpr size_t MAX_PINNED_MEM_SIZE = TOKiB((NUM_REGISTERED_BUFFERS + 1) * CHUNK_SIZE);  // 129 MiB = 132096 KB
-
-// GPU Bounce Buffer Slab Configuration
-// One 1 MB (1024 KB) slab to handle CHUNK_SIZE allocations
-static constexpr size_t SLAB_SIZES_KB[] = {1024};
-static constexpr size_t SLAB_COUNTS[] = {1};
-static constexpr int NUM_SLABS = 1;
-// Total cache: 1024 KB (1 MB)
+static constexpr size_t MAX_PINNED_MEM_SIZE = KiB(128);
+static constexpr size_t MAX_CACHE_SIZE = KiB(64);
 
 /*
  * Each thread allocates GPU memory and invokes cuFileBufRegister
@@ -196,17 +185,17 @@ int main(int argc, char *argv[]) {
 		});
 	};
 
-	// Set the maximum pinned memory size to 128 MiB
+	// Set the maximum pinned memory size to 128 KiB
 	status = cuFileDriverSetMaxPinnedMemSize(MAX_PINNED_MEM_SIZE);
 	if (status.err != CU_FILE_SUCCESS) {
 		std::cerr << "cuFileDriverSetMaxPinnedMemSize failed" << std::endl;
 		return EXIT_FAILURE;
 	}
 
-	// Set GPU bounce buffer slab configuration
-	status = cuFileSetParameterGpuBounceBufferSlabArray(SLAB_SIZES_KB, SLAB_COUNTS, NUM_SLABS);
+	// Set the maximum cache size to 64 KiB
+	status = cuFileDriverSetMaxCacheSize(MAX_CACHE_SIZE);
 	if (status.err != CU_FILE_SUCCESS) {
-		std::cerr << "cuFileSetParameterGpuBounceBufferSlabArray failed" << std::endl;
+		std::cerr << "cuFileDriverSetMaxCacheSize failed" << std::endl;
 		return EXIT_FAILURE;
 	}
 
@@ -215,8 +204,8 @@ int main(int argc, char *argv[]) {
 		std::cerr << "Error: cuFileDriverGetProperties failed" << std::endl;
 		return EXIT_FAILURE;
 	}
-	std::cout << "Setting max pinned memory size to: " << props.max_device_pinned_mem_size << " kilobytes" << std::endl;
-	std::cout << "Setting max cache size to: " << props.max_device_cache_size << " kilobytes (from slab configuration)" << std::endl;
+	std::cout << "Setting max pinned memory size to: " << props.max_device_pinned_mem_size << " bytes" << std::endl;
+	std::cout << "Setting max cache size to: " << props.max_device_cache_size << " bytes" << std::endl;
 
 	// Open an individual file descriptor for each thread and allow for half the threads
 	// to use registered buffers and the other half to use unregistered buffers

--- a/gds/samples/Makefile.pip
+++ b/gds/samples/Makefile.pip
@@ -129,7 +129,7 @@ install:
 	cp -r vectorAdd.cu Makefile README.md 1_cuFile_Basics/ 2_cuFile_Multithreaded/ 3_cuFile_Batch/ 4_cuFile_Async/ 5_cuFile_MemMap/ include/ common/ $(INSTALL_GDSSAMPLES_PREFIX)/
 
 clean:
-	find . -type f -executable -delete
+	rm -f $(objs) $(cuobjs) $(cusamples:.cu=_static)
 	rm -f *.o common/*.o cufile.log
 
 # Debug target to show detected paths

--- a/gds/samples/README.md
+++ b/gds/samples/README.md
@@ -6,6 +6,14 @@ In this directory, you will find sample programs which demonstrate usage of NVID
 
 <strong>Note:</strong> The sample tests expect the data files to exist and be at least 128 MiB in size. The data files should have read/write permissions in GDS enabled mounts. Cleanup is handled using `goto` statements for simplicity. For idiomatic C++ resource management using RAII, refer to our C++ cuFile bindings.
 
+## Tags
+
+The `main` branch is backwards compatible with older cuFile versions. See tags below for new features:
+
+| Tag | Description | Requirement |
+|-----|-------------|-------------|
+| `v1.17-cuda13.2` | Slab-based GPU bounce buffer configuration via `cuFileSetParameterGpuBounceBufferSlabArray` | cuFile 1.17 / CUDA 13.2+ |
+
 ## Layout
 
 ```


### PR DESCRIPTION
Latest MR into samples removed backwards compatibility for previous releases with regards to samples. These changes restore backwards compatibility alongside utilize tags to denote new features being added into samples.