### PR TITLE
sample: increasing maximum pinned memory

### DIFF
--- a/gds/samples/2_cuFile_Multithreaded/highly_concurrent_halfreg.cc
+++ b/gds/samples/2_cuFile_Multithreaded/highly_concurrent_halfreg.cc
@@ -1,5 +1,4 @@
-/*
- * Copyright 2020-2025 NVIDIA Corporation.  All rights reserved.
+/* Copyright 2020-2025 NVIDIA Corporation.  All rights reserved.
  *
  * Please refer to the NVIDIA end user license agreement (EULA) associated
  * with this source code for terms and conditions that govern your use of
@@ -14,16 +13,16 @@
  * copies of CUfileHandle_t, performing READs with different GPU buffers 
  * where half the threads have their buffers registered with cuFileBufRegister.
  * The number of threads are set to 64 with GPU buffers set to 4 along with the
- * maximum buffer space of 128 MiB which is pinned memory mapped to the
- * GPU BAR space along with 128 KiB cache size.
+ * maximum buffer space of 256 MiB which is pinned memory mapped to the
+ * GPU BAR space along with 64 MiB cache size.
  *
  * NOTE: This sample can run for awhile if file size is >= 1 GiB
  *
  * ./highly_concurrent_halfreg <testfile1> <testfile2> <gpuid>
  *
  * | Output |	
- * Setting max pinned memory size to: 131072 bytes
- * Setting max cache size to: 65536 bytes
+ * Setting max pinned memory size to: 262144 KiB
+ * Setting max cache size to: 65536 KiB
  * Successful read of 68719476736 bytes on thread 5 from fd 78 to GPU id 0 with unregistered buffers
  * Successful read of 68719476736 bytes on thread 41 from fd 114 to GPU id 0 with unregistered buffers
  * ...
@@ -54,7 +53,7 @@
 static constexpr size_t NUM_THREADS = 64;
 static constexpr size_t NUM_GPU_BUFFERS = 4;
 static constexpr size_t CHUNK_SIZE = MiB(1);
-static constexpr size_t MAX_PINNED_MEM_SIZE = KiB(128);
+static constexpr size_t MAX_PINNED_MEM_SIZE = KiB(256);
 static constexpr size_t MAX_CACHE_SIZE = KiB(64);
 
 /*
@@ -185,7 +184,7 @@ int main(int argc, char *argv[]) {
 		});
 	};
 
-	// Set the maximum pinned memory size to 128 KiB
+	// Set the maximum pinned memory size to 256 MiB
 	status = cuFileDriverSetMaxPinnedMemSize(MAX_PINNED_MEM_SIZE);
 	if (status.err != CU_FILE_SUCCESS) {
 		std::cerr << "cuFileDriverSetMaxPinnedMemSize failed" << std::endl;
@@ -204,8 +203,8 @@ int main(int argc, char *argv[]) {
 		std::cerr << "Error: cuFileDriverGetProperties failed" << std::endl;
 		return EXIT_FAILURE;
 	}
-	std::cout << "Setting max pinned memory size to: " << props.max_device_pinned_mem_size << " bytes" << std::endl;
-	std::cout << "Setting max cache size to: " << props.max_device_cache_size << " bytes" << std::endl;
+	std::cout << "Setting max pinned memory size to: " << props.max_device_pinned_mem_size << " KiB" << std::endl;
+	std::cout << "Setting max cache size to: " << props.max_device_cache_size << " KiB" << std::endl;
 
 	// Open an individual file descriptor for each thread and allow for half the threads
 	// to use registered buffers and the other half to use unregistered buffers


### PR DESCRIPTION
Bug was found within 2_cuFile_Multithreaded/highly_concurrent_halfreg where it was setting aside maximum pinned memory of 128 MiB. This was not enough given maximum pinned memory should be derived from the following equation:
    maximum_pinned_memory = cache_size + user_registered_gpu_buffers
We were previously not accounting for cache size. This fix now has the sample account for the cache.